### PR TITLE
Add cropping image from zoom to safe region and split to individual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 node_modules/
 package-lock.json
+yarn.lock
+
+images/*
+!images/.keep
+
+zoom-safe-region.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:14.12
+
+RUN apt-get update \
+    && apt-get install -qq build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+
+# Create app directory
+RUN mkdir -p /home/node/app
+WORKDIR /home/node/app
+
+# Install app dependencies
+COPY package.json /home/node/app
+COPY yarn.lock /home/node/app
+
+RUN chown -R node:node /home/node/app
+
+# USER node
+RUN yarn
+
+EXPOSE 300
+
+CMD yarn dev

--- a/app.js
+++ b/app.js
@@ -1,30 +1,90 @@
-const express = require('express')
-const app = express()
-const port = 3000
+const express = require("express");
+const imageToSlices = require("image-to-slices");
+const clipper = require("image-clipper");
+const canvas = require("canvas");
+const app = express();
+const port = 3000;
 
-const path = require('path');
-const fs = require('fs');
+const path = require("path");
+const fs = require("fs");
 
-const original_path = path.join(__dirname, 'screenshots');
+const original_path = path.join(__dirname, "screenshots");
 
-app.get('/', (req, res) => {
-  let images = []
+app.get("/", (req, res) => {
+  let images = [];
   fs.readdir(original_path, function (err, files) {
     if (err) {
-      return console.log('Unable to scan directory: ' + err);
+      return console.log("Unable to scan directory: " + err);
     }
     files.forEach(function (file) {
-      images.push(file)
+      images.push(file);
       console.log(file);
     });
-    console.log(images)
+    console.log(images);
 
-    res.json(files)
-
+    res.json(files);
   });
   // res.send('Hello World!')
-})
+});
+
+const cropImage = () => {
+  return new Promise((resolve, _) => {
+    clipper.configure("canvas", canvas);
+    clipper("./zoom.png", function () {
+      this.crop(26, 33, 590, 334)
+        .quality(100)
+        .toFile("./zoom-safe-region.png", function () {
+          resolve("done");
+        });
+    });
+  });
+};
+
+const sliceImage = () => {
+  return new Promise((resolve, _) => {
+    const lineX = [];
+    const lineY = [];
+    // Grid split
+    let lineXHeight = 0;
+    let lineYWidth = 0;
+    for (i = 1; i <= 6; i++) {
+      lineXHeight = lineXHeight + 48;
+      lineYWidth = lineYWidth + 84;
+      lineX.push(lineXHeight);
+      lineY.push(lineYWidth);
+    }
+    imageToSlices.configure({
+      clipperOptions: {
+        canvas,
+      },
+    });
+    console.log(lineY, lineX);
+    var source = "./zoom-safe-region.png";
+    imageToSlices(
+      source,
+      lineX,
+      lineY,
+      {
+        saveToDir: "./images/",
+      },
+      () => {
+        return resolve("done");
+      }
+    );
+  });
+};
+
+app.get("/slice-image", async (req, res) => {
+  try {
+    await cropImage();
+    await sliceImage();
+    return res.json({ msg: "done" });
+  } catch (err) {
+    console.log(err);
+    return res.statusCode(500).json({ msg: "something went wrong." });
+  }
+});
 
 app.listen(port, () => {
-  console.log(`Example app listening at http://localhost:${port}`)
-})
+  console.log(`Example app listening at http://localhost:${port}`);
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+
+services:
+  app:
+    build: .
+    volumes:
+      - ./:/home/node/app
+    ports:
+      - 3000:3000

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "app.js",
   "private": true,
   "scripts": {
-    "test": "node app.js"
+    "test": "node app.js",
+    "dev": "nodemon -L app.js"
   },
   "repository": {
     "type": "git",
@@ -25,7 +26,12 @@
     "npm": "6.14.8"
   },
   "dependencies": {
-    "express": "^4.17.1"
+    "canvas": "^2.6.1",
+    "express": "^4.17.1",
+    "image-clipper": "^0.4.4",
+    "image-to-slices": "^0.1.3"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "nodemon": "^2.0.6"
+  }
 }


### PR DESCRIPTION
Show case of cropping zoom image to safe region and individual as a fixed line X and Y also size as Readme mention that it can be hard coded.

### Safe region cropping
on file `zoom-safe-region.png`

![image](https://user-images.githubusercontent.com/16641152/97264804-2e6cc100-1858-11eb-9017-e24bbd43d030.png)

### Individual images
on folder `images/`

section 1
![image](https://user-images.githubusercontent.com/16641152/97264864-48a69f00-1858-11eb-9fd4-fd093404d2e4.png)
section 2
![image](https://user-images.githubusercontent.com/16641152/97264906-578d5180-1858-11eb-8116-45bd2ae4a01a.png)
section 3
![image](https://user-images.githubusercontent.com/16641152/97264918-5b20d880-1858-11eb-999f-cd7b73d6719e.png)

.... so on

What i have done
 - Build docker image to run canvas module in server side
 - Add library `canvas`, `image-clipper`, `image-to-slices`
 - APIs added `/slice-image` for cropping image from `zoom.png` as a sample zoom image
 - Path of file `zoom-safe-region.png` as a safe region `images/*` as a individual images (49 person)

How to run 
we need docker to run because dependencies required
```
cd zoom-gallery-view-cropping && docker-compose up -d
```
